### PR TITLE
Add PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "illuminate/contracts": "^8.0",
         "spatie/data-transfer-object": "^2.5.0",
         "thecodingmachine/safe": "^1.3"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Add support for PHP 8
- Upgrade PHPUnit to v9

Test suite passed locally both for 7.4 and 8.0.