### PR TITLE
Add support for passing flags to json_encode()

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ $user->address->calculateDistance($otherUser->address);
 echo (string) $user->address;
 ```
 
+### Controlling serialization
+
+You may provide caster with flags to be used for serialization by adding `CastUsingJsonFlags` attribute to your object:
+
+```php
+use JessArcher\CastableDataTransferObject\CastableDataTransferObject;
+use JessArcher\CastableDataTransferObject\CastUsingJsonFlags;
+
+#[CastUsingJsonFlags(encode: JSON_PRESERVE_ZERO_FRACTION)]
+class Address extends CastableDataTransferObject {}
+```
+
 ### Testing
 
 ``` bash

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.0"
+        "orchestra/testbench": "^6.4",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -8,22 +9,25 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+        </report>
+    </coverage>
     <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
     <php>
         <env name="DB_CONNECTION" value="testing"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>

--- a/src/CastUsingJsonFlags.php
+++ b/src/CastUsingJsonFlags.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace JessArcher\CastableDataTransferObject;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class CastUsingJsonFlags
+{
+    public function __construct(
+        public int $encode = 0,
+        public int $decode = 0,
+    ) {}
+}

--- a/src/CastableDataTransferObject.php
+++ b/src/CastableDataTransferObject.php
@@ -22,8 +22,8 @@ abstract class CastableDataTransferObject extends DataTransferObject implements 
         return json_encode($this->toArray(), $options);
     }
 
-    public static function fromJson(string $json)
+    public static function fromJson(string $json, int $options = 0)
     {
-        return new static(json_decode($json, true));
+        return new static(json_decode($json, assoc: true, options: $options));
     }
 }

--- a/src/Casts/DataTransferObject.php
+++ b/src/Casts/DataTransferObject.php
@@ -4,6 +4,8 @@ namespace JessArcher\CastableDataTransferObject\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use InvalidArgumentException;
+use JessArcher\CastableDataTransferObject\CastUsingJsonFlags;
+use ReflectionClass;
 
 class DataTransferObject implements CastsAttributes
 {
@@ -21,7 +23,7 @@ class DataTransferObject implements CastsAttributes
             return;
         }
 
-        return $this->class::fromJson($value);
+        return $this->class::fromJson($value, $this->getJsonFlags()->decode);
     }
 
     /**
@@ -41,6 +43,15 @@ class DataTransferObject implements CastsAttributes
             throw new InvalidArgumentException("Value must be of type [$this->class], array, or null");
         }
 
-        return $value->toJson();
+        return $value->toJson($this->getJsonFlags()->encode);
+    }
+
+    protected function getJsonFlags(): CastUsingJsonFlags
+    {
+         $attributes = (new ReflectionClass($this->class))
+            ->getAttributes(CastUsingJsonFlags::class);
+
+         return ($attributes[0] ?? null)?->newInstance()
+             ?? new CastUsingJsonFlags();
     }
 }

--- a/tests/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/tests/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,6 +21,8 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->jsonb('address')->nullable();
+            $table->jsonb('with_flags')->nullable();
+            $table->jsonb('without_flags')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This PR introduces support for passing flags to be used when serializing DTO to JSON.

```php
class User extends Model
{
    protected $casts = [
        'json_column' => SomeDTO::class.':preserveZeroFraction,prettyPrint,invalidUtf8Ignore',
    ];
}
```

This example would result in following flags being used:

```php
json_encode($dto->toArray(), JSON_PRESERVE_ZERO_FRACTION | JSON_PRETTY_PRINT | JSON_INVALID_UTF8_IGNORE);
```

The PR is based on top of changes in #7 and resolves #5.