### PR TITLE
chore: allow safe dependency v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8.0",
         "illuminate/contracts": "^8.0|^9.0",
         "spatie/data-transfer-object": "^3.0",
-        "thecodingmachine/safe": "^1.3"
+        "thecodingmachine/safe": "^1.3|^2.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.2",


### PR DESCRIPTION
Resolves some dependency conflicts with other libraries.  PHP 8 support wasn't added to `thecodingmachine/safe` until v2.0, and since this library requires PHP 8 it makes sense to at least support this version of the library.